### PR TITLE
Fixes comparison between pointer and integer.

### DIFF
--- a/Src/FuncApprox/PsuadeRegression.cpp
+++ b/Src/FuncApprox/PsuadeRegression.cpp
@@ -73,7 +73,7 @@ int PsuadeRegression::genNDGridData(double *X, double *Y, int *N2,
 {
   int totPts, ss;
 
-  if (N2 <= 0)
+  if ((*N2) <= 0)
   {
     printf("PsuadeRegression::genNDGridData - ERROR detected (N <= 0).\n");
     (*N2) = 0;


### PR DESCRIPTION
Psuade fails to build with GCC 7.3.0 due to an invalid comparison between a pointer and an integer. This pull request fixes the code so it builds and behaves as expected.